### PR TITLE
Add "useMediaQuery" hook

### DIFF
--- a/src/hooks/useMediaQuery.ts
+++ b/src/hooks/useMediaQuery.ts
@@ -9,7 +9,7 @@ const parseQueryString = (query: string) => {
   return query.replaceAll("@media only screen and", "").trim();
 };
 
-export const useMediaQuery = (query: string, defaultState: boolean | null = null) => {
+export const useMediaQuery = (query: string, defaultState = false) => {
   const parseAndMatch = (s: string) => getMatch(parseQueryString(s));
   const [state, setState] = useState(isClient ? () => parseAndMatch(query).matches : defaultState);
 

--- a/src/hooks/useMediaQuery.ts
+++ b/src/hooks/useMediaQuery.ts
@@ -1,0 +1,40 @@
+import { useEffect, useState } from "react";
+import { isClient } from "~/utils/common";
+
+interface Props {
+  query: string;
+  defaultState?: boolean | null;
+}
+
+const getMatch = (query: string) => {
+  return window.matchMedia(query);
+};
+
+const parseQueryString = (query: string) => {
+  return query.replaceAll("@media only screen and", "").trim();
+};
+
+export const useMediaQuery = ({ query, defaultState = null }: Props) => {
+  const parseAndMatch = (s: string) => getMatch(parseQueryString(s));
+  const [state, setState] = useState(isClient ? () => parseAndMatch(query).matches : defaultState);
+
+  useEffect(() => {
+    let mounted = true;
+    const mql = parseAndMatch(query);
+
+    const onChange = () => {
+      if (!mounted) return;
+      setState(!!mql.matches);
+    };
+
+    mql.addEventListener("change", onChange);
+    setState(mql.matches);
+
+    return () => {
+      mounted = false;
+      mql.removeEventListener("change", onChange);
+    };
+  }, [query]);
+
+  return state;
+};

--- a/src/hooks/useMediaQuery.ts
+++ b/src/hooks/useMediaQuery.ts
@@ -1,11 +1,6 @@
 import { useEffect, useState } from "react";
 import { isClient } from "~/utils/common";
 
-interface Props {
-  query: string;
-  defaultState?: boolean | null;
-}
-
 const getMatch = (query: string) => {
   return window.matchMedia(query);
 };
@@ -14,7 +9,7 @@ const parseQueryString = (query: string) => {
   return query.replaceAll("@media only screen and", "").trim();
 };
 
-export const useMediaQuery = ({ query, defaultState = null }: Props) => {
+export const useMediaQuery = (query: string, defaultState: boolean | null = null) => {
   const parseAndMatch = (s: string) => getMatch(parseQueryString(s));
   const [state, setState] = useState(isClient ? () => parseAndMatch(query).matches : defaultState);
 


### PR DESCRIPTION
We were using this hook for our latest projects, so I feel it makes sense to have it included by default.
I have adapted the parsing of the media query, so that we can directly pass our [screen utility](https://github.com/madebywild/wild-next/blob/next-2020/src/styles/screens.ts) functions:

```ts
import { up } from '~/styles/screens`;
const isLg = useMediaQuery(up("lg"));
```

The hook takes two arguments: the required media query to check and optionally a default state. The default state is used when initializing the effect as well as during server side rendering. It currently defaults to `null`.

Maybe we should only allow it to be either `true` or `false` to avoid confusion?