### PR TITLE
feat(global-styles): dont show overflow by default

### DIFF
--- a/src/styles/GlobalStyles.tsx
+++ b/src/styles/GlobalStyles.tsx
@@ -4,7 +4,7 @@ import tw, { GlobalStyles as BaseStyles } from "twin.macro";
 
 const CustomStyles = createGlobalStyle`
   html {
-    ${tw`bg-white text-black cursor-default leading-none overflow-y-scroll min-h-full`}
+    ${tw`bg-white text-black cursor-default leading-none min-h-full`}
   }
 
   body {


### PR DESCRIPTION
Most scroll-lock-libs will use the `body` element to do their magic.
Sometimes this causes issues when the documentElement has a visible scrollbar.

Also, this change makes the boilerplate a bit less opinionated overall, which is probably a good thing.