### PR TITLE
build(twin): add babel-plugin-twin

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -1,6 +1,7 @@
 module.exports = {
   presets: ["next/babel"],
   plugins: [
+    "twin",
     "macros",
     [
       "styled-components",

--- a/docs/styling.md
+++ b/docs/styling.md
@@ -7,13 +7,6 @@ This project uses [TailwindCSS](https://tailwindcss.com/) and [styled-components
 Use the `tw` prop when there are no conditional styles, and you don't need custom CSS.<br />**This should always be preferred!**
 
 ```tsx
-/**
- * We still need to import the macro, because it provides the custom JSX transform
- * that enables the `tw` prop. If no import is present, the compiler will default to
- * react-jsx, which does not know how to handle the `tw` prop.
- */
-import "twin.macro";
-
 return () => (
   <div tw="flex w-full">
     <div tw="w-1/2" />

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "@types/react": "17.0.1",
         "@types/styled-components": "5.1.9",
         "@types/webpack-env": "1.16.0",
+        "babel-plugin-twin": "1.0.2",
         "eslint": "7.24.0",
         "husky": "6.0.0",
         "lint-staged": "10.5.4",
@@ -2598,6 +2599,15 @@
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
       "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
+    },
+    "node_modules/babel-plugin-twin": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-twin/-/babel-plugin-twin-1.0.2.tgz",
+      "integrity": "sha512-723f0tizypoy3Fn9ZAuidTCQ+sKh6sn/jX+Cjj3Pk148ew/hUa+fRUyqAPKACIFaVNqRFnZgI1DoNhNMDL+6QA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/template": "^7.12.13"
+      }
     },
     "node_modules/balanced-match": {
       "version": "1.0.0",
@@ -11313,6 +11323,15 @@
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
       "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
+    },
+    "babel-plugin-twin": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-twin/-/babel-plugin-twin-1.0.2.tgz",
+      "integrity": "sha512-723f0tizypoy3Fn9ZAuidTCQ+sKh6sn/jX+Cjj3Pk148ew/hUa+fRUyqAPKACIFaVNqRFnZgI1DoNhNMDL+6QA==",
+      "dev": true,
+      "requires": {
+        "@babel/template": "^7.12.13"
+      }
     },
     "balanced-match": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@types/react": "17.0.1",
     "@types/styled-components": "5.1.9",
     "@types/webpack-env": "1.16.0",
+    "babel-plugin-twin": "1.0.2",
     "eslint": "7.24.0",
     "husky": "6.0.0",
     "lint-staged": "10.5.4",

--- a/src/layouts/DefaultPage.tsx
+++ b/src/layouts/DefaultPage.tsx
@@ -1,4 +1,3 @@
-import "twin.macro";
 import React from "react";
 
 interface Props {}


### PR DESCRIPTION
-  Add the [babel plugin for twin](https://github.com/ben-rogerson/babel-plugin-twin), which auto-imports the twin macro when needed.
- This gets rid of the stand-alone twin import.