### PR TITLE
feat: disable cleanupIDs

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -26,7 +26,7 @@ const nextConfig = {
                 {
                   name: "preset-default",
                   params: {
-                    overrides: { removeViewBox: false },
+                    overrides: { removeViewBox: false, cleanupIDs: false },
                   },
                 },
               ],


### PR DESCRIPTION
I've run into some problems with more complex svgs with some shapes and IDs inside, and the plugin was removing such IDs, resulting in the svg having missing parts.